### PR TITLE
[REFACTOR] chapter 2-4 리팩터링

### DIFF
--- a/chapter2/dpfls/refactor-chapter2-4.java
+++ b/chapter2/dpfls/refactor-chapter2-4.java
@@ -1,5 +1,5 @@
-public static void copyChars (char a1[], char a2[]) {
-  for (int i = 0; i < a1.length; i++) {
-    a2 [i] = a1[i];
-  }
+public static void copyChars(char source[], char destination[]) {
+    for (int i = 0; i < source.length; i++) {
+        destination[i] = source[i];
+    }
 }


### PR DESCRIPTION
## Bad Code인 이유
- 불필요한 띄어쓰기가 있음
- a1과 a2의 순서가 중요하기 때문에 배열의 이름에 의미를 담아야 함

## 리팩토링 방법
- a1과 a2의 의미를 담음
- format을 맞춤