### PR TITLE
[REFACTOR] chapter3-4

### DIFF
--- a/chapter3/euna/refactor-chapter3-4.java
+++ b/chapter3/euna/refactor-chapter3-4.java
@@ -1,0 +1,83 @@
+public class HtmlRenderer {
+  private StringBuffer renderBuffer = new StringBuffer();
+
+  public static String getHtmlWithTest(PageData pageData, boolean includeSuiteSetup) {
+    WikiPage wikiPage = pageData.getWikiPage();
+    boolean hasTest = pageData.hasAttribute("Test");
+
+    if (hasTest) {
+      setupTest(includeSuiteSetup);
+    }
+
+    appendPageData();
+
+    if (hasTest) {
+      teardownTest(includeSuiteSetup);
+    }
+
+    renderHtml()
+    return pageData.getHtml();
+  }
+
+  private void setupTest(boolean includeSuiteSetup) {
+    if (includeSuiteSetup) {
+      WikiPage suiteSetupWikiPage = PageCrawlerImp.getInheritedPage(...);
+      appendSetupLogToBuffer(suiteSetupWikiPage);
+    }
+
+    WikiPage setupWikiPage = PageCrawlerImp.getInheritedPage(...);
+    appendSetupLogToBuffer(setupWikiPage);
+  }
+
+  private void appendSetupLogToBuffer(WikiPage wikiPage) {
+    if (wikiPage != null) {
+      String wikiPagePathName = getWikiPagePathName(wikiPage);
+      renderBuffer.append("!include -setup .")
+            .append(wikiPagePathName)
+            .append("\n");
+    }
+  }
+
+  private void teardownTest(boolean includeSuiteSetup) {
+    WikiPage teardownWikiPage = PageCrawlerImpl.getInheritedPage(...);
+    appendTeardownLogToBuffer(teardownWikiPage);
+
+    if (includeSuiteSetup) {
+      WikiPage suiteTeardown = PageCrawlerImpl.getInheritedPage(...);
+      appendTeardownLogToBuffer(suiteTeardown, includeSuiteSetup);
+    }
+  }
+
+  private void appendTeardownLogToBuffer(WikiPage wikiPage) {
+    if (wikiPage != null) {
+      String wikiPagePathName = getWikiPagePathName(wikiPage);
+      renderBuffer.append("\n")
+            .append("!include -teardown .")
+            .append(wikiPagePathName)
+            .append("\n");
+    }
+  }
+
+  private void appendTeardownLogToBuffer(WikiPage wikiPage, boolean includeSuiteSetup) {
+    if (wikiPage != null) {
+      String wikiPagePathName = getWikiPagePathName(wikiPage);
+      renderBuffer.append(includeSuiteSetup ? "" : "\n")
+            .append("!include -teardown .")
+            .append(wikiPagePathName)
+            .append("\n");
+    }
+  }
+
+  private String getWikiPagePathName(WikiPage wikiPage) {
+    WikiPagePath wikiPagePath = wikiPage.getFullPath();
+    return PathParser.render(wikiPagePath);
+  }
+
+  private void appendPageData() {
+    renderBuffer.append(pageData.getContent());
+  }
+
+  private void renderHtml() {
+    pageData.setContent(renderBuffer.toString());
+  }
+}


### PR DESCRIPTION
### 문제라고 생각한 부분
- testableHtml이라는 메서드명이 모호하여 어떤 일을 하는지 구체적으로 알기 어렵다고 생각합니다.
- setup과 teardown 세부 구현이 그대로 드러나있어 코드의 의도를 파악하기 어렵습니다.

### 리팩터링 요소
- setup과 teardown 로직을 setupTest, teardownTest 메서드로 분리했습니다.
- setupTest과 teardownTest에서 버퍼에 로그를 추가하는 로직을 appendSetupLogToBuffer, appendTeardownLogToBuffer로 분리했습니다.
- path name을 찾는 로직을 getWikiPagePathName 메서드로 분리했습니다.
- 버퍼에 pageContent를 추가하고, pageData를 버퍼에 담긴 내용으로 set하는 로직을 appendPageData, renderHtml 메서드로 추출해서 코드의 의도를 더 구체적으로 표현했습니다.
- 테스트를 포함하여 html을 구성하는 전체 context를 더 잘 드러내기 위해 클래스로 재구성했습니다.
