### PR TITLE
[REFACTOR] chapter 4-3

### DIFF
--- a/chapter4/haesa/refactor-chapter4-3.java
+++ b/chapter4/haesa/refactor-chapter4-3.java
@@ -1,0 +1,23 @@
+private void startSending() {
+  try {
+    doSending();
+  } catch(SocketException e) {
+    // normal. someone stopped the request.
+  } catch(Exception e) {
+    handleError(e)
+  }
+}
+
+/**
+  개인적으로 함수 인터페이스와 catch 블럭에서 Exception 이름이 동일해도 되는지 궁금함!
+  1. 동일한 이름을 사용하면 컴파일 레벨에서 오류가 난다
+  2. 오류는 안 나지만, 일반적으로 혼란을 방지하기 위해 일부러 다르게 쓴다
+*/
+private void makeExceptionMessageAndCloseResponse(Exception e) {
+  try {
+    response.add(ErrorResponder.makeExceptionString(e));
+    response.closeAll();
+  } catch (Exception e) {
+    //Give me a break!
+  }
+}

--- a/chapter4/haesa/refactor-chapter4-3.java
+++ b/chapter4/haesa/refactor-chapter4-3.java
@@ -10,14 +10,13 @@ private void startSending() {
 
 /**
   개인적으로 함수 인터페이스와 catch 블럭에서 Exception 이름이 동일해도 되는지 궁금함!
-  1. 동일한 이름을 사용하면 컴파일 레벨에서 오류가 난다
-  2. 오류는 안 나지만, 일반적으로 혼란을 방지하기 위해 일부러 다르게 쓴다
+  1. 동일한 이름을 사용하면 컴파일 레벨에서 오류가 난다 ✅
 */
 private void addExceptionMessageAndCloseResponse(Exception e) {
   try {
     response.add(ErrorResponder.makeExceptionString(e));
     response.closeAll();
-  } catch (Exception e) {
-    //Give me a break!
+  } catch (Exception e1) {
+    ...
   }
 }

--- a/chapter4/haesa/refactor-chapter4-3.java
+++ b/chapter4/haesa/refactor-chapter4-3.java
@@ -13,7 +13,7 @@ private void startSending() {
   1. 동일한 이름을 사용하면 컴파일 레벨에서 오류가 난다
   2. 오류는 안 나지만, 일반적으로 혼란을 방지하기 위해 일부러 다르게 쓴다
 */
-private void makeExceptionMessageAndCloseResponse(Exception e) {
+private void addExceptionMessageAndCloseResponse(Exception e) {
   try {
     response.add(ErrorResponder.makeExceptionString(e));
     response.closeAll();

--- a/chapter4/haesa/refactor-chapter4-3.java
+++ b/chapter4/haesa/refactor-chapter4-3.java
@@ -4,7 +4,7 @@ private void startSending() {
   } catch(SocketException e) {
     // normal. someone stopped the request.
   } catch(Exception e) {
-    handleError(e)
+    addExceptionMessageAndCloseResponse(e)
   }
 }
 


### PR DESCRIPTION
### 문제라고 생각한 부분
- try-catch 블럭이 중첩되어 코드 가독성이 떨어짐

### 리팩터링 요소
- 중첩된 try-catch 블럭을 메서드로 분리
  - 해당 로직이 두 가지 일을 수행하고 있지만, 원래 의도상 분리할 수 없다고 판단함
  - 대신 메서드 이름에 두 가지 일을 모두 포함시킴 (사이드 이펙트 방지 차원)
